### PR TITLE
use AggregateComplete for Multisig account if only one approval.

### DIFF
--- a/__tests__/views/forms/FormTransactionBase.spec.ts
+++ b/__tests__/views/forms/FormTransactionBase.spec.ts
@@ -1,0 +1,74 @@
+import { FormTransactionBase } from '@/views/forms/FormTransactionBase/FormTransactionBase';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { WalletsModel1 } from '@MOCKS/Accounts';
+import { TransactionCommandMode } from '@/services/TransactionCommand';
+import Vuex from 'vuex';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+const accountModule = {
+    namespaced: true,
+    getters: {
+        isCosignatoryMode: () => true,
+        currentAccount: () => [WalletsModel1],
+        currentSignerMultisigInfo: () => {
+            return {
+                minApproval: 0,
+            };
+        },
+    },
+};
+
+const store = new Vuex.Store({
+    modules: {
+        account: accountModule,
+    },
+});
+store.commit = jest.fn();
+store.dispatch = jest.fn();
+
+const options = {
+    localVue,
+    store,
+};
+
+let wrapper;
+let vm;
+
+beforeEach(() => {
+    wrapper = shallowMount(FormTransactionBase, options);
+    vm = wrapper.vm;
+});
+
+describe('FormTransactionBase', () => {
+    it('getTransactionCommandMode should return AGGREGATE given minApproval equal 1', () => {
+        // arrange
+        wrapper.setData({
+            currentSignerMultisigInfo: {
+                minApproval: 1,
+            },
+        });
+
+        // act
+        const mode = vm.getTransactionCommandMode([]);
+
+        // assert
+        expect(mode).toBe(TransactionCommandMode.AGGREGATE);
+    });
+
+    it('getTransactionCommandMode should return MULTISIGN given minApproval equal 2', () => {
+        // arrange
+        wrapper.setData({
+            currentSignerMultisigInfo: {
+                minApproval: 2,
+            },
+        });
+
+        // act
+        const mode = vm.getTransactionCommandMode([]);
+
+        // assert
+        expect(mode).toBe(TransactionCommandMode.MULTISIGN);
+    });
+});

--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -288,7 +288,7 @@ export class FormTransactionBase extends Vue {
 
     protected getTransactionCommandMode(transactions: Transaction[]): TransactionCommandMode {
         if (this.isMultisigMode()) {
-            // If min Approval equal one, we can announce it with AggregateComplete to ski[ the lock fees.
+            // If min Approval equal one, we can announce it with AggregateComplete to skip the lock fees.
             if (this.currentSignerMultisigInfo.minApproval === 1) {
                 return TransactionCommandMode.AGGREGATE;
             }

--- a/src/views/forms/FormTransactionBase/FormTransactionBase.ts
+++ b/src/views/forms/FormTransactionBase/FormTransactionBase.ts
@@ -288,6 +288,11 @@ export class FormTransactionBase extends Vue {
 
     protected getTransactionCommandMode(transactions: Transaction[]): TransactionCommandMode {
         if (this.isMultisigMode()) {
+            // If min Approval equal one, we can announce it with AggregateComplete to ski[ the lock fees.
+            if (this.currentSignerMultisigInfo.minApproval === 1) {
+                return TransactionCommandMode.AGGREGATE;
+            }
+
             return TransactionCommandMode.MULTISIGN;
         }
         if (transactions.length > 1) {

--- a/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmationTs.ts
+++ b/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmationTs.ts
@@ -238,7 +238,7 @@ export class ModalTransactionConfirmationTs extends Vue {
     }
     protected getTransactionCommandMode(transactions: Transaction[]): TransactionCommandMode {
         if (this.isMultisigMode()) {
-            // If min Approval equal one, we can announce it with AggregateComplete to ski[ the lock fees.
+            // If min Approval equal one, we can announce it with AggregateComplete to skip the lock fees.
             if (this.currentSignerMultisigInfo.minApproval === 1) {
                 return TransactionCommandMode.AGGREGATE;
             }

--- a/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmationTs.ts
+++ b/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmationTs.ts
@@ -238,6 +238,11 @@ export class ModalTransactionConfirmationTs extends Vue {
     }
     protected getTransactionCommandMode(transactions: Transaction[]): TransactionCommandMode {
         if (this.isMultisigMode()) {
+            // If min Approval equal one, we can announce it with AggregateComplete to ski[ the lock fees.
+            if (this.currentSignerMultisigInfo.minApproval === 1) {
+                return TransactionCommandMode.AGGREGATE;
+            }
+
             return TransactionCommandMode.MULTISIGN;
         }
         if (transactions.length > 1) {


### PR DESCRIPTION
### Fix
- Use AggregateComplete for Multisig account if min Approval equal 1

Resolved: #1344 