### PR TITLE
fix: removed the overflow in css

### DIFF
--- a/src/components/MultisigCosignatoriesDisplay/MultisigCosignatoriesDisplay.vue
+++ b/src/components/MultisigCosignatoriesDisplay/MultisigCosignatoriesDisplay.vue
@@ -126,7 +126,6 @@ export default class MultisigCosignatoriesDisplay extends MultisigCosignatoriesD
 }
 
 /deep/ .inputs-container {
-    overflow: auto !important;
     height: auto;
 }
 </style>


### PR DESCRIPTION
### Fix
- The little grey block actually is the scroll bar, just removed overflow in the CSS.

To reproduce the issue on the web application, just adjust the browser window to smaller.

Resolved: #1557